### PR TITLE
Account for sites that have wordpress in it's own directory AND is recorded that way in the db

### DIFF
--- a/src/MsDbuCommand.php
+++ b/src/MsDbuCommand.php
@@ -139,7 +139,7 @@ class MsDbuCommand extends WP_CLI_Command {
    * @throws ExitException
    */
   public function __invoke(array $args, array $assoc_args ) {
-
+    WP_CLI::debug('Beginning database update command.');
     $this->setUpRoutesAndDomain($assoc_args);
 
     //we have to set up the routes and domain data in order to determine if we've already updated.
@@ -216,8 +216,11 @@ class MsDbuCommand extends WP_CLI_Command {
      * depending on how you ask for it. get_option should *not* include it.
      */
     $siteInDb = get_option('siteurl');
+    WP_CLI::debug("siteInDb is $siteInDb");
+
     if (false === strpos($this->defaultSearchURL,$siteInDb)) {
       //already updated
+      WP_CLI::debug(sprintf('false when comparing site in db to defaultSearchURL %s',$this->defaultSearchURL));
       return true;
     } else {
       //we need to update
@@ -394,7 +397,7 @@ class MsDbuCommand extends WP_CLI_Command {
    * @todo seems like some of these we could use a magic get and just return the correct data?
    */
   protected function setDefaultSearchURL(): void {
-    $this->defaultSearchURL = $this->defaultDomainInfo[$this->defaultReplaceURLFull]['production_url'];
+    $this-> defaultSearchURL = $this->defaultDomainInfo[$this->defaultReplaceURLFull]['production_url'];
   }
 
   /**

--- a/src/MsDbuCommand.php
+++ b/src/MsDbuCommand.php
@@ -218,7 +218,7 @@ class MsDbuCommand extends WP_CLI_Command {
     $siteInDb = get_option('siteurl');
     WP_CLI::debug("siteInDb is $siteInDb");
 
-    if (false === strpos($this->defaultSearchURL,$siteInDb)) {
+    if (false === strpos(parse_url($this->defaultSearchURL,PHP_URL_HOST),parse_url($siteInDb,PHP_URL_HOST))) {
       //already updated
       WP_CLI::debug(sprintf('false when comparing site in db to defaultSearchURL %s',$this->defaultSearchURL));
       return true;
@@ -400,7 +400,7 @@ class MsDbuCommand extends WP_CLI_Command {
   protected function setDefaultSearchURL(): void {
     $this->defaultSearchURL = $this->defaultDomainInfo[$this->defaultReplaceURLFull]['production_url'];
     WP_CLI::debug(sprintf('Setting defaultSearchURL to %s', $this->defaultSearchURL ));
-    WP_CLI::debug(sprintf('This is based on a defaultReplaceURLFull of %s, and default domainInfo of '.PHP_EOL,$this->defaultReplaceURLFull),var_export($this->defaultDomainInfo,true));
+    WP_CLI::debug(sprintf('This is based on a defaultReplaceURLFull of %s, and default domainInfo of %s'.PHP_EOL,$this->defaultReplaceURLFull),var_export($this->defaultDomainInfo,true));
   }
 
   /**

--- a/src/MsDbuCommand.php
+++ b/src/MsDbuCommand.php
@@ -389,6 +389,7 @@ class MsDbuCommand extends WP_CLI_Command {
    */
   protected function setDefaultReplaceURL(): void {
     $this->defaultReplaceURLFull = array_key_first($this->defaultDomainInfo);
+    WP_CLI::debug(sprintf('Setting defaultReplaceURLFull to %s',$this->defaultReplaceURLFull));
   }
 
   /**
@@ -397,7 +398,9 @@ class MsDbuCommand extends WP_CLI_Command {
    * @todo seems like some of these we could use a magic get and just return the correct data?
    */
   protected function setDefaultSearchURL(): void {
-    $this-> defaultSearchURL = $this->defaultDomainInfo[$this->defaultReplaceURLFull]['production_url'];
+    $this->defaultSearchURL = $this->defaultDomainInfo[$this->defaultReplaceURLFull]['production_url'];
+    WP_CLI::debug(sprintf('Setting defaultSearchURL to %s', $this->defaultSearchURL ));
+    WP_CLI::debug(sprintf('This is based on a defaultReplaceURLFull of %s, and default domainInfo of '.PHP_EOL,$this->defaultReplaceURLFull),var_export($this->defaultDomainInfo,true));
   }
 
   /**

--- a/src/MsDbuCommand.php
+++ b/src/MsDbuCommand.php
@@ -400,7 +400,7 @@ class MsDbuCommand extends WP_CLI_Command {
   protected function setDefaultSearchURL(): void {
     $this->defaultSearchURL = $this->defaultDomainInfo[$this->defaultReplaceURLFull]['production_url'];
     WP_CLI::debug(sprintf('Setting defaultSearchURL to %s', $this->defaultSearchURL ));
-    WP_CLI::debug(sprintf('This is based on a defaultReplaceURLFull of %s, and default domainInfo of %s'.PHP_EOL,$this->defaultReplaceURLFull),var_export($this->defaultDomainInfo,true));
+    WP_CLI::debug(sprintf('This is based on a defaultReplaceURLFull of %s, and default domainInfo of %s'.PHP_EOL,$this->defaultReplaceURLFull,var_export($this->defaultDomainInfo,true)));
   }
 
   /**


### PR DESCRIPTION
To determine if we have already processed the URLs in the db, we compare the default search url with the url of the site in the database. In some situations where wordpress is in a subdirectory, this would cause a false positive.  